### PR TITLE
Linking markdown docs in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,5 +313,14 @@ You can add custom translations for the actions [:new, :show, :edit, :destroy]
     show: Show company
 ```
 
+## Additional Docs
+You can find more detailed docs in the links below
+
+- [Action](docs/action.md)
+- [Field](docs/field.md)
+- [Presenter](docs/presenter.md)
+- [Scope](docs/scope.md)
+
+
 ##TODO
 * create has many association input data


### PR DESCRIPTION
Just a small improvement to the docs, this PR shows the link for the additional markdown documentation in the README.md.
