### PR TITLE
Removing Carnival migration auto inclusion

### DIFF
--- a/lib/carnival/engine.rb
+++ b/lib/carnival/engine.rb
@@ -1,11 +1,5 @@
 module Carnival
   class Engine < ::Rails::Engine
     #isolate_namespace Carnival
-    #
-    initializer :append_migrations do |app|
-      config.paths["db/migrate"].expanded.each do |expanded_path|
-        app.config.paths["db/migrate"] << expanded_path
-      end
-    end
   end
 end


### PR DESCRIPTION
This commit remove code that was previously used to run Carnival migrations with user migrations.
Since Carnival migrations were removed this code is no longer needed.
