### PR TITLE
Fix method format that has been deprecated by simple_form

### DIFF
--- a/app/inputs/admin_currency_input.rb
+++ b/app/inputs/admin_currency_input.rb
@@ -3,7 +3,7 @@ class AdminCurrencyInput < SimpleForm::Inputs::Base
   include ActionView::Helpers::NumberHelper
   include AdminBaseInput
 
-  def input
+  def input(wrapper_options)
     default_input_html_options = {class: 'money',
       value: number_with_precision(@builder.object.send(attribute_name), separator: ",", precision: 2) }
     options = merge_options(default_input_html_options, input_html_options)

--- a/app/inputs/admin_date_input.rb
+++ b/app/inputs/admin_date_input.rb
@@ -2,7 +2,7 @@ class AdminDateInput < SimpleForm::Inputs::Base
 
   include AdminBaseInput
 
-  def input
+  def input(wrapper_options)
     format = if column.type == :datetime then '%Y/%m/%d %H:%M' else '%Y/%m/%d' end
     default_input_html_options = {class: "#{column.type}picker",
       value: @builder.object.send(attribute_name).nil? ? "" : @builder.object.send(attribute_name).strftime(format)}

--- a/app/inputs/admin_enum_input.rb
+++ b/app/inputs/admin_enum_input.rb
@@ -1,5 +1,5 @@
 class AdminEnumInput < SimpleForm::Inputs::CollectionSelectInput
-  def input
+  def input(wrapper_options)
     super
     input_html_options[:class] << ' carnival-select'
 

--- a/app/inputs/admin_previewable_file_input.rb
+++ b/app/inputs/admin_previewable_file_input.rb
@@ -1,8 +1,8 @@
 class AdminPreviewableFileInput < SimpleForm::Inputs::FileInput
-  def input
+  def input(wrapper_options)
     template.image_tag(object.send(attribute_name).url(:thumb), class: 'previewable') + super
   end
-  
+
   def input_html_classes
     super.push('previewable')
   end

--- a/app/inputs/admin_relationship_select_input.rb
+++ b/app/inputs/admin_relationship_select_input.rb
@@ -1,5 +1,5 @@
 class AdminRelationshipSelectInput < SimpleForm::Inputs::CollectionSelectInput
-  def input
+  def input(wrapper_options)
     super
     input_html_options[:class] << ' carnival-select'
     if input_html_options[:data][:depends_on].nil?

--- a/app/inputs/carnival_select_remote_input.rb
+++ b/app/inputs/carnival_select_remote_input.rb
@@ -1,5 +1,5 @@
 class CarnivalSelectRemoteInput < SimpleForm::Inputs::CollectionSelectInput
-  def input
+  def input(wrapper_options)
     super
     input_html_options[:class] << 'hidden-select'
     collection = []

--- a/app/models/carnival/form.rb
+++ b/app/models/carnival/form.rb
@@ -61,7 +61,6 @@ module Carnival
       end
       if nil_values > 0
         nil_column_size = 12 - (line_size / nil_values)
-        puts nil_column_size
         line.each do |column|
           column.size = nil_column_size if not column.size.present?
         end


### PR DESCRIPTION
Simple form will remove the method input form its inputs without a wrapper_options argument so all methods should change from

``` ruby
def input
...
end
```

to

``` ruby
def input(wrapper_options)
...
end
```
