### PR TITLE
Change model name lookup in controller

### DIFF
--- a/app/controllers/carnival/base_admin_controller.rb
+++ b/app/controllers/carnival/base_admin_controller.rb
@@ -4,12 +4,6 @@ module Carnival
     respond_to :html, :json
     layout "carnival/admin"
 
-    def self.inherited(base)
-      base.send(:defaults, instance_name: 'model')
-      model_name = base.name.split('::').last.gsub('Controller', '').singularize
-      base.send(:defaults, resource_class: model_name.constantize)
-    end
-
     def home
 
     end
@@ -26,7 +20,7 @@ module Carnival
 
     def presenter_name field
       field_name =  field.split('/').last
-      carnival_mount = Carnival::Config.mount_at
+      carnival_mount = Carnival::Config.mount_at 
       "#{carnival_mount}/#{field_name.singularize}_presenter".classify.constantize
     end
 
@@ -60,6 +54,7 @@ module Carnival
     def show
       @model_presenter = instantiate_presenter
       show! do |format|
+        @model = instance_variable_get("@#{resource_instance_name}")
         format.html do |render|
           render 'show' and return
         end
@@ -69,6 +64,7 @@ module Carnival
     def new
       @model_presenter = instantiate_presenter
       new! do |format|
+        @model = instance_variable_get("@#{resource_instance_name}")
         format.html do |render|
           render 'new' and return
         end
@@ -78,6 +74,7 @@ module Carnival
     def edit
       @model_presenter = instantiate_presenter
       edit! do |format|
+        @model = instance_variable_get("@#{resource_instance_name}")
         format.html do |render|
           render 'edit' and return
         end
@@ -89,6 +86,7 @@ module Carnival
       create! do |success, failure|
         success.html{ redirect_to @model_presenter.model_path(:index), :notice => I18n.t("messages.created") and return}
         failure.html do |render|
+          @model = instance_variable_get("@#{resource_instance_name}")
           render 'new' and return
         end
       end
@@ -99,6 +97,7 @@ module Carnival
       update! do |success, failure|
         success.html{ redirect_to @model_presenter.model_path(:index), :notice => I18n.t("messages.updated") and return}
         failure.html do |render|
+          @model = instance_variable_get("@#{resource_instance_name}")
           render 'edit' and return
         end
       end
@@ -125,7 +124,7 @@ module Carnival
       model.where("#{search_field} like '%#{params[:q]}%'").each do |elem|
         list << {id: elem.id, text: elem.send(search_field.to_sym)}
       end
-
+      
       render :json => list
     end
     private

--- a/app/views/carnival/base_admin/show.html.haml
+++ b/app/views/carnival/base_admin/show.html.haml
@@ -1,5 +1,4 @@
 - index_path = caminho_modelo(:index)
-- item = @model
 .gray_border.with_margin_bottom
   %h1= t("#{@model_presenter.model_name}.show", default: t('carnival.show'))
   .action_back
@@ -11,11 +10,11 @@
       - line.each do |field|
         .wrapper_show{class: "col-md-#{field.size}"}
           - if show_view(@model_presenter, field.name)
-            = render partial: show_view(@model_presenter, field.name), locals: { model: item, model_name: @model_presenter.full_model_name, field_name: field.name  }
+            = render partial: show_view(@model_presenter, field.name), locals: { model: @model, model_name: @model_presenter.full_model_name, field_name: field.name  }
           - else
             %label="#{translate_field(@model_presenter, field)}:"
             .value
               - if show_as_list @model_presenter,field.name
-                = render 'carnival/shared/show/show_as_list', items: item.send(field.name.to_s)
+                = render 'carnival/shared/show/show_as_list', items: @model.send(field.name.to_s)
               - else
-                = field_to_show @model_presenter,field.name,item
+                = field_to_show @model_presenter, field.name, @model


### PR DESCRIPTION
This way of looking up a model name, if a cliente changes the default model name in inherited resource config, Carnival will not break.
