### PR TITLE
Atualização rails 4.2

### DIFF
--- a/app/helpers/carnival/base_admin_helper.rb
+++ b/app/helpers/carnival/base_admin_helper.rb
@@ -90,7 +90,7 @@ module Carnival
       rendered = field_value_and_type presenter, field_name, record
       field_type = rendered[:field_type]
       value = rendered[:value]
-
+      
       is_relation = presenter.relation_field?(field_name)
 
       unless value.nil?

--- a/app/inputs/admin_relationship_select_input.rb
+++ b/app/inputs/admin_relationship_select_input.rb
@@ -15,7 +15,7 @@ class AdminRelationshipSelectInput < SimpleForm::Inputs::CollectionSelectInput
     end
 
     @builder.collection_select(
-      "#{@builder.object.class.name.constantize.reflections[attribute_name.to_sym].foreign_key}",
+      "#{HashWithIndifferentAccess.new(@builder.object.class.name.constantize.reflections)[attribute_name.to_sym].foreign_key}",
       collection,
       :first, :last,
       {prompt: I18n.t("#{@builder.object.class.to_s.gsub(/^.*::/, '').downcase}.lista_#{attribute_name}.selecione", default: I18n.t("messages.select"))},

--- a/app/inputs/carnival_select_remote_input.rb
+++ b/app/inputs/carnival_select_remote_input.rb
@@ -18,7 +18,7 @@ class CarnivalSelectRemoteInput < SimpleForm::Inputs::CollectionSelectInput
     end
 
     html = @builder.collection_select(
-      "#{@builder.object.class.name.constantize.reflections[attribute_name.to_sym].foreign_key}",
+      "#{HashWithIndifferentAccess.new(@builder.object.class.name.constantize.reflections)[attribute_name.to_sym].foreign_key}",
       collection,
       :first, :last,
       {prompt: I18n.t("#{@builder.object.class.to_s.gsub(/^.*::/, '').downcase}.lista_#{attribute_name}.selecione", default: I18n.t("messages.select"))},

--- a/app/presenters/carnival/base_admin_presenter.rb
+++ b/app/presenters/carnival/base_admin_presenter.rb
@@ -317,7 +317,7 @@ module Carnival
       if relation_field?(field.to_sym) then :relation
       elsif type == :date || type == :datetime then type
       elsif type == :number || type == :float then :number
-      elsif type == :integer and model_class.const_defined? field.upcase then :enum
+      elsif type == :integer and model_class.const_defined? field.upcase and field != :id then :enum
       else type
       end
     end

--- a/app/views/carnival/base_admin/index.csv.haml
+++ b/app/views/carnival/base_admin/index.csv.haml
@@ -2,5 +2,5 @@
   - csv_line = []
   - @presenter.fields_for_action(:csv).each do |key, field|
     - csv_line << field_value_and_type(@presenter, key,record)[:value]
-  = "#{csv_line.join(',')}\n"
+  = "#{csv_line.join(',')}"
 

--- a/app/views/carnival/shared/form/_form.html.haml
+++ b/app/views/carnival/shared/form/_form.html.haml
@@ -26,14 +26,8 @@
 
     newForm = $(newForm).html()
     var container = $(target).parents("." + form).find(selector);
-    var last_index = container.find("li").length
-    newForm = newForm.replace(new RegExp("(_" + form + "_attributes_)\\d+(_[a-zA-Z]+)", "g"), "$1" + last_index + "$2");
-
-    newForm = newForm.replace(new RegExp("(\\[" + form + "_attributes\\]\\[)\\d+(\\]\\[[a-zA-Z]+\\])", "g"), "$1" + last_index + "$2");
-    //newForm = newForm.replace(/([_a-zA-Z]+\[[_a-zA-Z]+_attributes\]\[)\d+(\]\[[_a-zA-Z]+\])/g, "$1" + last_index + "$2");
-
-    /*name.match(/\[[0-1]\]\[\w*\]/g);
-      .parents('.nested-form-list')*/
+    var last_index = container.children("li").length;
+    newForm = replaceInputIndexes(newForm, form, container, last_index);
 
     container.append(newForm);
     container.find("li:last")[0].scrollIntoView(true)
@@ -44,6 +38,21 @@
     lastFormAdded.find('.select2-remote').each(function(){
       addSelect2ToField(this);
     });
+  }
+
+  function replaceInputIndexes(newForm, form, container, index){
+    newForm = newForm.replace(new RegExp("(_" + form + "_attributes_)\\d+(_[a-zA-Z]+)", "g"), "$1" + index + "$2");
+    newForm = newForm.replace(new RegExp("(\\[" + form + "_attributes\\]\\[)\\d+(\\]\\[[a-zA-Z_]+\\])", "g"), "$1" + index + "$2");
+
+    if (container.parents('.nested-form-list').length){
+      var parent = container.parents('.nested-form-list');
+      var parentForm = getFormName(parent.children(":first"));
+      var parentIndex = container.parents('li').index();
+
+      newForm = replaceInputIndexes(newForm, parentForm, parent, parentIndex);
+    }    
+
+    return newForm;
   }
 
   function getFormName(element){

--- a/app/views/carnival/shared/form/_form.html.haml
+++ b/app/views/carnival/shared/form/_form.html.haml
@@ -16,7 +16,7 @@
     $(".nested-form-subtitle").hide();
   });
 
-  function createNewForm(selector, form){
+  function createNewForm(selector, form, target){
     $(".nested-form-subtitle").show();
 
     newForm = $(nestedForms[form]).clone().wrap("<div>").parent();
@@ -25,15 +25,22 @@
     $(newForm).find("select").show();
 
     newForm = $(newForm).html()
-    var last_index = $(selector + " li").length
-    newForm = newForm.replace(/([_a-zA-Z]+_attributes_)\d+(_[a-zA-Z]+)/g, "$1" + last_index + "$2");
-    newForm = newForm.replace(/([_a-zA-Z]+\[[_a-zA-Z]+_attributes\]\[)\d+(\]\[[_a-zA-Z]+\])/g, "$1" + last_index + "$2");
-    $(selector).append(newForm);
-    $(selector + " li:last")[0].scrollIntoView(true)
-    $(selector + " li:last").find(".carnival-select").select2({width: '100%'});
+    var container = $(target).parents("." + form).find(selector);
+    var last_index = container.find("li").length
+    newForm = newForm.replace(new RegExp("(_" + form + "_attributes_)\\d+(_[a-zA-Z]+)", "g"), "$1" + last_index + "$2");
+
+    newForm = newForm.replace(new RegExp("(\\[" + form + "_attributes\\]\\[)\\d+(\\]\\[[a-zA-Z]+\\])", "g"), "$1" + last_index + "$2");
+    //newForm = newForm.replace(/([_a-zA-Z]+\[[_a-zA-Z]+_attributes\]\[)\d+(\]\[[_a-zA-Z]+\])/g, "$1" + last_index + "$2");
+
+    /*name.match(/\[[0-1]\]\[\w*\]/g);
+      .parents('.nested-form-list')*/
+
+    container.append(newForm);
+    container.find("li:last")[0].scrollIntoView(true)
+    container.find("li:last .carnival-select").select2({width: '100%'});
 
     setupDateFields();
-    var lastFormAdded = $(selector).find(".nested-form-list-item").last();
+    var lastFormAdded = container.find(".nested-form-list-item").last();
     lastFormAdded.find('.select2-remote').each(function(){
       addSelect2ToField(this);
     });

--- a/app/views/carnival/shared/form/_nested_form.html.haml
+++ b/app/views/carnival/shared/form/_nested_form.html.haml
@@ -9,10 +9,10 @@
         = render '/carnival/shared/form/nested_form_options', opt_obj: opt
     - else
       .carnival-select-action
-        = link_to t("nested_form.new"), '#', onclick: "createNewForm('.nested-form-list.#{field.name}', '#{field.name}'); return false;", class: "carnival-action-button novo"
+        = link_to t("nested_form.new"), '#', onclick: "createNewForm('.nested-form-list.#{field.name}', '#{field.name}', this); return false;", class: "carnival-action-button novo"
 
       - if field.nested_form_modes?(:new)
-        %ul.nested-form-list{:class => field.name}
+        %ul.nested-form-list{:class => "#{field.name}"}
           - model_object.send(field.name).build
           = f.simple_fields_for field.name.to_sym do |inner_form|
             %li.nested-form-list-item{:class => "#{inner_form.object.id.nil? and inner_form.object.errors.size == 0 ? 'form-new-association' : 'form-existent-association'}" }


### PR DESCRIPTION
Nas versões anteriores do Rails, as keys da hash @builder.object.class.name.constantize.reflections era symbol, agora é string. Para funcionar nas duas versões, converti para uma hash com acesso indiferente das keys.