### PR TITLE
Join do filtro no search_field passado

### DIFF
--- a/app/services/carnival/presenters/advanced_search_parser.rb
+++ b/app/services/carnival/presenters/advanced_search_parser.rb
@@ -41,13 +41,12 @@ module Carnival
           end
 
           if @klass_service.relation? search_field.to_sym
-            related_model = @klass_service.get_related_class(search_field.to_sym).name.underscore
-            foreign_key = @klass_service.get_foreign_key(search_field.to_sym)
             if @klass_service.is_a_belongs_to_relation?(search_field.to_sym)
-              records = records.joins(related_model.split("/").last.to_sym)
+              records = records.joins(search_field.split("/").last.to_sym)
             else
-              records = records.joins(related_model.split("/").last.pluralize.to_sym)
+              records = records.joins(search_field.split("/").last.pluralize.to_sym)
             end
+            related_model = @klass_service.get_related_class(search_field.to_sym).name.underscore
             table = related_model.split("/").last.classify.constantize.table_name
             column = "id" if column.nil?
           else


### PR DESCRIPTION
1. Retirei um foreign_key que não estava sendo usado em lugar nenhum na função.

2. Troquei o joins para ser feito no search_field ao invés do related_model para casos em que se troca o nome da relation, não usando o nome do model.