### PR TITLE
Fix nested form pre built models

### DIFF
--- a/app/views/carnival/shared/form/_form.html.haml
+++ b/app/views/carnival/shared/form/_form.html.haml
@@ -9,8 +9,11 @@
   $(document).ready(function(){
     nestedForm = $(".nested-form-list .form-new-association").each(function(index, element){
       nestedForms[getFormName(element)] = element;
-      element.remove();
     });
+
+    for (var element in nestedForms) {
+      nestedForms[element].remove();
+    }
 
     $(".existing-options").hide();
     $(".nested-form-subtitle").hide();
@@ -50,7 +53,7 @@
       var parentIndex = container.parents('li').index();
 
       newForm = replaceInputIndexes(newForm, parentForm, parent, parentIndex);
-    }    
+    }
 
     return newForm;
   }


### PR DESCRIPTION
* If a Carnival user wanted to pre populate the nested forms lists, it
  wasn't possible, because Carnival would remove every new form from the
  DOM, now it removes only the last one, which was built by Carnival