### PR TITLE
Improvements in the search form, and changes in the field render partial 

### DIFF
--- a/app/assets/javascripts/carnival/advanced_search.js
+++ b/app/assets/javascripts/carnival/advanced_search.js
@@ -6,20 +6,16 @@ $(document).ready(function(){
     $(".as-form-overlay").click(function(e){
       $(".as-form-overlay").remove();
       $("#advanced_search_form").hide();
-      $(".select2-drop").hide();      
+      $(".select2-drop").hide();
       return false
     });
     return false
   });
 
 
-  $("#search_button").click(function(e){
-    e.preventDefault();
-
-    var queryParams = [];
-
-    Carnival.submitIndexForm();
-  });
+  $(".carnival-index-form form").submit(function(e){
+    Carnival.cleanIndexForm();
+  })
 
   $("#clear_button").click(function(e){
     e.preventDefault();
@@ -36,5 +32,3 @@ $(document).ready(function(){
     Carnival.submitIndexForm();
   });
 });
-
-

--- a/app/assets/javascripts/carnival/vizir_admin.js.erb
+++ b/app/assets/javascripts/carnival/vizir_admin.js.erb
@@ -51,6 +51,10 @@ Carnival.callFunc = function(functionName, data){
 }
 
 Carnival.submitIndexForm = function(){
+  $(".carnival-index-form form").submit();
+}
+
+Carnival.cleanIndexForm = function(){
   $("#advanced_search_form input").each(function(){
     var inputValue = $(this).val();
 
@@ -64,8 +68,6 @@ Carnival.submitIndexForm = function(){
     if(inputValue == "-1")
       $(this).val('');
   });
-  var form = $('.carnival-index-form').find('form')
-  form.submit();
 }
 
 Carnival.setIndexPageParam = function(name, value){

--- a/app/assets/stylesheets/carnival/search.css.scss
+++ b/app/assets/stylesheets/carnival/search.css.scss
@@ -156,3 +156,16 @@
 .select2-drop {
   z-index: 99999999999 !important;
 }
+
+.advanced-search button{
+  background: #007ae1;
+  color: #fff;
+  margin-top: 8px;
+  border: 1px solid rgba(0, 0, 0, 0.21);
+  border-radius: 2px;
+  padding: 0px 15px;
+}
+
+.advanced-search button:hover{
+  color: #fff
+}

--- a/app/helpers/carnival/base_admin_helper.rb
+++ b/app/helpers/carnival/base_admin_helper.rb
@@ -86,7 +86,7 @@ module Carnival
 
     def field_to_show(presenter, field_name, record, show_only_values=false)
       if presenter.fields[field_name].params[:as] == :partial
-        raw(render field_name.to_s, record: record)
+        raw(render presenter.fields[field_name].params[:partial_name], record: record)
       else
         rendered = field_value_and_type presenter, field_name, record
         field_type = rendered[:field_type]
@@ -144,9 +144,7 @@ module Carnival
     end
 
     def translate_field(presenter, field_name)
-      field = presenter.get_field(field_name)
-      field_key = field.name_for_translation
-      presenter.model_class.human_attribute_name field_key
+      presenter.translate_field(field_name)
     end
 
     def list_cel(presenter, field, record, only_render_fields)

--- a/app/models/carnival/field.rb
+++ b/app/models/carnival/field.rb
@@ -158,7 +158,6 @@ module Carnival
     end
 
     def sort_name
-      return @params[:related_to].to_s if @params[:related_to].present?
       @name.to_s
     end
 

--- a/app/presenters/carnival/base_admin_presenter.rb
+++ b/app/presenters/carnival/base_admin_presenter.rb
@@ -344,6 +344,17 @@ module Carnival
       end
     end
 
+    def translate_field field_name
+      field = get_field(field_name)
+      if field.specified_association?
+        related_class = model_class.reflect_on_association(field.association_name).klass
+        related_class.human_attribute_name(field.association_field_name)
+      else
+        field_key = field.name_for_translation
+        model_class.human_attribute_name field_key
+      end
+    end
+
     protected
 
     def make_relation_advanced_query_url_options(field, record)

--- a/app/services/carnival/presenters/advanced_search_parser.rb
+++ b/app/services/carnival/presenters/advanced_search_parser.rb
@@ -46,8 +46,7 @@ module Carnival
             else
               records = records.joins(search_field.split("/").last.pluralize.to_sym)
             end
-            related_model = @klass_service.get_related_class(search_field.to_sym).name.underscore
-            table = related_model.split("/").last.classify.constantize.table_name
+            table = @klass_service.get_related_class(search_field.to_sym).table_name
             column = "id" if column.nil?
           else
             table = @klass_service.table_name

--- a/app/services/carnival/query_service.rb
+++ b/app/services/carnival/query_service.rb
@@ -37,10 +37,9 @@ module Carnival
 
     def scopes_number
       records = records_without_pagination_and_scope
-
-      Hash[@presenter.scopes.keys.map do |key|
+      @presenter.scopes.keys.map do |key|
         [key, scope_query(records, key).size]
-      end]
+      end.to_h
     end
 
     def scope_query(records, scope = @query_form.scope)

--- a/app/views/carnival/shared/_advanced_search.html.haml
+++ b/app/views/carnival/shared/_advanced_search.html.haml
@@ -7,19 +7,15 @@
     %li.search_item
       .search_field
         .label
-          - label_field = presenter.get_field(field)
-          - translation_prefix = "activerecord.attributes.#{presenter.full_model_name}"
-          - if presenter.relation_field?(label_field)
-            = label_tag key, t("#{translation_prefix}.#{key.to_s.gsub('.', '_')}")
-          - else
-            = label_tag key, t("#{translation_prefix}.#{key}")
+          = label_tag key, presenter.translate_field(field)
         .field
           = render '/carnival/shared/advanced_search_field', :field => field, :presenter => presenter, :value => value
   %li.search_item
     .action
       = link_to t("clear"), "#", :id=> "clear_button", :class => "carnival-action-button clear-search"
     .action
-      = link_to t("search"), "#", :id=> "search_button", :class => "carnival-action-button search-submit"
+      %button{type:"submit", :id=> "search_button", :class => "carnival-action-button search-submit"}
+        = t("search")
 
 %ul.advanced-search-tags
   - presenter.advanced_search_fields.each do |key, field|

--- a/app/views/carnival/shared/_advanced_search_field.html.haml
+++ b/app/views/carnival/shared/_advanced_search_field.html.haml
@@ -10,5 +10,7 @@
     = select_tag "advanced_search[#{field.name}]", options_for_select([['',''],['true', 'true'],['false', 'false']], value)
   - elsif presenter.field_type(field.name) == :datetime
     = text_field_tag "advanced_search[#{field.name}]", value, "data-operator" => field.advanced_search_operator, :class => "datepicker"
+  - elsif field.params[:as] == :partial
+    = text_field_tag "advanced_search[#{field.params[:related_to]}]", value, "data-operator" => field.advanced_search_operator
   - else
     = text_field_tag "advanced_search[#{field.name}]", value, "data-operator" => field.advanced_search_operator

--- a/app/views/carnival/shared/_advanced_search_field.html.haml
+++ b/app/views/carnival/shared/_advanced_search_field.html.haml
@@ -10,7 +10,5 @@
     = select_tag "advanced_search[#{field.name}]", options_for_select([['',''],['true', 'true'],['false', 'false']], value)
   - elsif presenter.field_type(field.name) == :datetime
     = text_field_tag "advanced_search[#{field.name}]", value, "data-operator" => field.advanced_search_operator, :class => "datepicker"
-  - elsif field.params[:as] == :partial
-    = text_field_tag "advanced_search[#{field.params[:related_to]}]", value, "data-operator" => field.advanced_search_operator
   - else
     = text_field_tag "advanced_search[#{field.name}]", value, "data-operator" => field.advanced_search_operator

--- a/app/views/carnival/shared/form/_field.html.haml
+++ b/app/views/carnival/shared/form/_field.html.haml
@@ -10,7 +10,7 @@
 - options[:input_html] = {}
 - options[:input_html][:class] = "field-#{field.name}"
 - options[:input_html][:data] = {}
-- options[:input_html][:data][:presenter_name] = presenter.presenter_name 
+- options[:input_html][:data][:presenter_name] = presenter.presenter_name
 
 - if options[:as].is_a? Hash
   - options[:input_html][:data][:carnival_options] = options[:as].first[1]
@@ -28,6 +28,6 @@
 
 - options[:label] = translate_field(presenter, field)
 - if options[:as] == :partial
-  = render field.name.to_s, f: f, record: f.object
+  = render options[:partial_name], f: f, record: f.object
 - else
   = f.input field.name, options

--- a/docs/field.md
+++ b/docs/field.md
@@ -29,21 +29,24 @@
   ```ruby
     :sortable => true
   ```
-  
+
+#### :partial_name
+  - Define the partial to be used to render the field value, this parameter must be used with the ```as: :partial```, because it's only checked when the field is defined to rendered ```as: :partial```
+
 #### :as
-  - Define the type of the render that will be used to render the field. If the type passed as parameter to SimpleForm, as a type of Input. The only exception is the :partial parameter that is explained below. 
-  
+  - Define the type of the render that will be used to render the field. If the type passed as parameter to SimpleForm, as a type of Input. The only exception is the :partial parameter that is explained below.
+
   ##### as: :partial
-  Instead of rendereing a field, Carnival fill search for a partial with the field name. The following declaration inside AuthorsPresenter
-  
+  Instead of rendereing a field, Carnival will render a partial instead of the default field render, the name of the partial to be rendered must be defined in the ```:partial_name``` parameter. The following declaration inside AuthorsPresenter
+
 ```ruby
-    field :custom_partial, actions: [:edit], as: :partial 
+    field :field_name, actions: [:edit], as: :partial, partial_name: "custom_partial"
   ```
-  Carnival will try to render the partial '_custom_partial.html.haml' inside /app/views/authors. 
-  To be more useful the following objects are available to the called partial: 
-  * record: available to all partials, it represents de current record being displayed. 
+  Carnival will try to render the partial '_custom_partial.html.haml' inside /app/views/authors.
+  To be more useful the following objects are available to the called partial:
+  * record: available to all partials, it represents de current record being displayed.
   * f: when a new or edit action is being rendered, the 'f' object will contain the current form being rendered.
-  
+
 
 ## Relations
 ### Many relations


### PR DESCRIPTION
## Field with render as: :partial

  The Field key in the presenter must not be the partial name anymore, the field key must be the field that will be used to make the data operations (search, order, form, etc.) the partial must be defined in the new parameter called :partial_name . With this change the parameter :related_to was killed.

## Search form

  Change the action search to use a submit button intead of a link, to permit use the default submit with enter key in any field of the form.

  Change the way Carnival lookups for the label translations to use the active_record translations, so if the models are translated the search form will respect the translations of the model.