### PR TITLE
Fix index as

### DIFF
--- a/app/views/carnival/base_admin/index.html.haml
+++ b/app/views/carnival/base_admin/index.html.haml
@@ -51,28 +51,27 @@
             - if column[:sort_function] != ''
               %option{ :selected => column[:name] == @query_form.sort_column && 'asc' == @query_form.sort_direction, :data => {column_name: "#{column[:name]}", sort_dir: "asc"} ,  "class" => "#{column[:class]}"}= "#{translate_field(presenter, column[:field])} - &#9650;".html_safe
               %option{ :selected => column[:name] == @query_form.sort_column && 'desc' == @query_form.sort_direction, :data => {column_name: "#{column[:name]}", sort_dir: "desc"} ,  "class" => "#{column[:class]}"}= "#{translate_field(presenter, column[:field])} - &#9660;".html_safe
-
-- if @records.any?
-
+- if presenter.index_as
   = render "index_as_#{presenter.index_as}", :params => params, presenter: presenter
-
-  .carnival-footer-tools
-
-    .table-paginate
-      - @paginator.pages.each do |page_hash|
-        %span{class: page_hash[:css_class]}
-          = link_to(t(page_hash[:label]), page_hash[:js_function], :class => "carnival-action-button")
-      = "#{t('paginate_total')}: #{@query_service.total_records}"
-
-    .table-download-links
-      - params = @query_form.to_hash
-      = link_to t('download_as_csv'), presenter.model_path(:index, { format: 'csv' }.merge(params)), class: 'carnival-action-button csv' if presenter.has_action?(:csv)
-
 - else
-  .empty-result
-    %h1
-      = t('no_results')
-    %h4
-      %span
-      - presenter.actions_for_page.each do |key, action|
-        = render '/carnival/shared/action_default', :label=>t("#{presenter.model_name}.#{action.name}", default: t("carnival.#{action.name}")), :path=> action.path(presenter)
+  - if @records.any?
+    .carnival-footer-tools
+
+      .table-paginate
+        - @paginator.pages.each do |page_hash|
+          %span{class: page_hash[:css_class]}
+            = link_to(t(page_hash[:label]), page_hash[:js_function], :class => "carnival-action-button")
+        = "#{t('paginate_total')}: #{@query_service.total_records}"
+
+      .table-download-links
+        - params = @query_form.to_hash
+        = link_to t('download_as_csv'), presenter.model_path(:index, { format: 'csv' }.merge(params)), class: 'carnival-action-button csv' if presenter.has_action?(:csv)
+
+  - else
+    .empty-result
+      %h1
+        = t('no_results')
+      %h4
+        %span
+        - presenter.actions_for_page.each do |key, action|
+          = render '/carnival/shared/action_default', :label=>t("#{presenter.model_name}.#{action.name}", default: t("carnival.#{action.name}")), :path=> action.path(presenter)

--- a/config/locales/carnival.en.yml
+++ b/config/locales/carnival.en.yml
@@ -5,6 +5,7 @@ en:
     new: New
     edit: Edit
     destroy: Delete
+    index: List
     errors:
       invalid_field:  "The actions '%{actions}' are invalid for field '%{field}' for presenter '%{presenter}'"
 


### PR DESCRIPTION
The partial defined on the `index_as` was not presented when the list was empty. 

I fixed this bug and changed to show only the `index_as` partial when it is defined. So now with the `index_as` defined you can customize even the pagination.

I also add the `carnival.index` translation in the `en.yml`.