### PR TITLE
Move render_field from helper to presenter

### DIFF
--- a/app/helpers/carnival/base_admin_helper.rb
+++ b/app/helpers/carnival/base_admin_helper.rb
@@ -106,10 +106,7 @@ module Carnival
     end
 
     def field_value_and_type(presenter, field_name, record)
-      renderer = FieldRenderers::RendererCreator
-                 .create_field_renderer(presenter, field_name)
-
-      renderer.render_field(record)
+      presenter.render_field(field_name, record)
     end
 
     def is_image?(field_type, value)

--- a/app/presenters/carnival/base_admin_presenter.rb
+++ b/app/presenters/carnival/base_admin_presenter.rb
@@ -344,6 +344,14 @@ module Carnival
       end
     end
 
+    def render_field(field_name, record)
+      renderer_for(field_name).render_field(record)
+    end
+
+    def renderer_for(field_name)
+      FieldRenderers::RendererCreator.create_field_renderer(self, field_name)
+    end
+
     protected
 
     def make_relation_advanced_query_url_options(field, record)


### PR DESCRIPTION
This way presenter subtypes will have a chance to override this  behavior without monkey patching Carnival