### PR TITLE
Documentation revision

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,172 @@ gem 'carnival'
 ```
 
 Run `bundle install`.
+
+Then, execute `rails generate carnival:install` to generate the initializer.
+
+### Basic Usage
+
+Carnival started relying only on MVC model. As we developed it, we realized that a Presenter would better describe our models. We used the presenter to avoid fat models to emerge on our design.
+
+### Model
+
+It is a regular Active Record model. We only have to include the Carnival Helper:
+
+```ruby
+module Admin
+  class Company < ActiveRecord::Base
+    include Carnival::ModelHelper
+  end
+end
+```
+
+### Controller
+
+It is also a regular Controller, with some minor differences:
+
+* Inherits from `Carnival::BaseAdminController`
+* Uses the default admin layout: `layout 'carnival/admin'`
+* When creating or editing data, you should configure the permitted params.
+
+```ruby
+module Admin
+  class CompaniesController < Carnival::BaseAdminController
+    layout 'carnival/admin'
+
+    # ...
+
+    private
+
+    def permitted_params
+      params.permit(admin_company: [:name])
+    end
+  end
+end
+```
+
+See more about the Controller at [Controller Properties](docs/controller.md)
+
+### Presenter
+
+All the "magic" of Carnival happens at Presenter. Each model managed under Carnival Admin will have a presenter associated to it. The presenter describes how the model's attributes will be presented.
+
+```ruby
+module Admin
+  class CompanyPresenter < Carnival::BaseAdminPresenter
+    field :id,
+          actions: [:index, :show], sortable: false,
+          advanced_search: { operator: :equal }
+    field :name,
+          actions: [:index, :new, :edit, :show],
+          advanced_search: { operator: :like }
+    field :created_at, actions: [:index, :show]
+
+    action :show
+    action :edit
+    action :destroy
+    action :new
+  end
+end
+```
+
+See more about the Presenter at [Presenter Properties](docs/presenter.md).
+
+### Menu
+
+The menu of Carnival can be configured in the 'config/initializers/carnival_initializers.rb' file.
+
+Eg.:
+
+``` ruby
+config.menu = {
+  city: {
+    label: 'city',
+    class: '',
+    link: 'admin_cities_path', # You can use the route name as String to define the link
+    subs: [
+      {
+        label: 'custom_city',
+        class: '',
+        link: 'admin/custom/cities', # You can also use the full path
+      },
+      {
+        label: 'google',
+        class: '',
+        link: 'http://www.google.com'
+      }
+    ]
+  },
+
+  # ...
+}
+```
+
+## Customizing Carnival
+
+### Custom Views
+
+Carnival permits that you specify some partials for your page, you just need to add your partial in the `app/views/carnival/extra_header.html.haml`.
+
+Possible Partials:
+
+- `extra_header`
+  - Extra HTML to render in page header.
+
+- `app_logo`
+  - Define a specific partial for your app logo.
+  - Default Value: `link_to <App Name>, root_path`
+
+- `extra_footer`
+  - Extra HTML to render in page footer.
+
+### Configurations
+
+#### Custom AdminUser
+
+If you want to have your own AdminUser class or need to add methods to that class, you need to do the following steps:
+
+- Configure the `ar_admin_user_class` in the `carnival/_initializers.rb` file.
+
+``` ruby
+  config.devise_class_name = 'MyAdminClass'
+```
+
+- Your class need to inherit from `Carnival::AdminUser`.
+
+#### Custom Root Action
+
+``` ruby
+  config.root_action = 'my_controller#my_action'
+```
+
+#### Application Name
+
+``` ruby
+  config.app_name = 'Application Name'
+```
+
+### I18n
+
+You can add custom translations for the actions [:new, :show, :edit, :destroy]
+
+```ruby
+  company:
+    new: Create New company
+    show: Show company
+```
+
+### Integrations
+
+It can be easily integrated with gems that you already know and use.
+
+#### Authentication
+
+* [Devise](docs/integrations/devise.md)
+
+#### Rich Text Editor
+
+* [CKEditor](docs/integrations/ckeditor.mb.md)
+
+#### File upload
+
+* [Paperclip](docs/integrations/paperclip.md)

--- a/README.md
+++ b/README.md
@@ -6,18 +6,17 @@ By
 Carnival is an easy-to-use and extensible Rails Engine to speed up the development of data management interfaces.
 It provides a managing infra-structure for your application.
 
-When you use Carnival you'll benefit from a set of features already done. If you need to change anything, you can write your own version of the code, using real Ruby code in Rails standard components without worrying about a specific syntax or DSL.
+When you use Carnival you'll benefit from a set of features out-of-the-box. If you need to change anything, you can write your own version of the code, using real Ruby code in Rails standard components without worrying about a specific syntax or DSL.
 
-* How it works
- - Carnival works with Rails 4.0 onwards.
+## Requirements
+* Carnival works with Rails 4.0 onwards.
 
 ## Features
-
 * Easy way to CRUD any data;
 * Search data easily. Advanced searches in a minute. You can specify which fields you want to search for;
 * Fancy time filter, based on Toggl design;
 * Nice default layout, ready to use;
-* New and Edit forms are easily configured. If you do not like, you can write your own views.
+* New and Edit forms are easily configured. If you do not like them, you can write your own views.
 
 ## Detailed features
 
@@ -75,175 +74,3 @@ gem 'carnival'
 ```
 
 Run `bundle install`.
-
-Then, execute `rails generate carnival:install` to generate the initializer.
-
-### Basic Usage
-
-Carnival started relying only on MVC model. As we developed it, we realized that a Presenter would better describe our models. We used the presenter to avoid fat models to emerge on our design.
-
-### Model
-
-It is a commom Active Record model. We only have to include the Carnival Helper:
-
-```ruby
-module Admin
-  class Company < ActiveRecord::Base
-    include Carnival::ModelHelper
-  end
-end
-```
-
-### Controller
-
-It is also a commom Controller, with some minor differences:
-
-* Inherits from `Carnival::BaseAdminController`
-* Uses the default admin layout: `layout 'carnival/admin'`
-* When creating or editing data, you should configure the permitted params.
-
-See more [Controller](docs/controller.md)
-
-```ruby
-module Admin
-  class CompaniesController < Carnival::BaseAdminController
-    layout 'carnival/admin'
-
-    # ...
-
-    private
-
-    def permitted_params
-      params.permit(admin_company: [:name])
-    end
-  end
-end
-```
-
-### Presenter
-
-All the "magic" of Carnival happens at Presenter. Each model managed under Carnival Admin will have a presenter associated to it. The presenter describes how the model's attributes will be presented.
-
-See more [Presenter](docs/presenter.md)
-
-```ruby
-module Admin
-  class CompanyPresenter < Carnival::BaseAdminPresenter
-    field :id,
-          actions: [:index, :show], sortable: false,
-          advanced_search: { operator: :equal }
-    field :name,
-          actions: [:index, :new, :edit, :show],
-          advanced_search: { operator: :like }
-    field :created_at, actions: [:index, :show]
-
-    action :show
-    action :edit
-    action :destroy
-    action :new
-  end
-end
-```
-
-See more about the Presenter at [Presenter Properties](docs/presenter.md).
-
-### Menu
-
-The menu of the carnival can be configured in the 'config\initializers\carnival_initializers.rb' file.
-
-Eg.:
-
-``` ruby
-config.menu = {
-  city: {
-    label: 'city',
-    class: '',
-    link: 'admin_cities_path', # You can use the route name as String to define the link
-    subs: [
-      {
-        label: 'custom_city',
-        class: '',
-        link: 'admin/custom/cities', # You can also use the full path
-      },
-      {
-        label: 'google',
-        class: '',
-        link: 'http://www.google.com'
-      }
-    ]
-  },
-
-  # ...
-}
-```
-
-## Customizing Carnival
-
-### Custom Views
-
-Carnival permits that you specify some partials for your page, you just need add your partial in the `app/views/carnival/extra_header.html.haml`.
-
-Possible Partials:
-
-- `extra_header`
-  - Extra html to render in page header.
-
-- `app_logo`
-  - Define a specific partial for your app logo.
-  - Default Value: `link_to <App Name>, root_path`
-
-- `extra_footer`
-  - Extra html to render in page footer.
-
-### Configurations
-
-#### Custom AdminUser
-
-If you want to have your own AdminUser class or need to add methods to that class, you need to do the following steps:
-
-- Configure the `ar_admin_user_class` in the `carnival/_initializers.rb` file.
-
-``` ruby
-  config.devise_class_name = 'MyAdminClass'
-```
-
-- Your class need to inherit from `Carnival::AdminUser`.
-
-#### Custom Root Action
-
-``` ruby
-  config.root_action = 'my_controller#my_action'
-```
-
-#### Application Name
-
-``` ruby
-  config.app_name = 'Application Name'
-```
-
-### I18n
-
-You can add custom translations for the actions [:new, :show, :edit, :destroy]
-
-```ruby
-  company:
-    new: Create New company
-    show: Show company
-```
-
-### Integrations
-
-It can be easily integrated with gems that you are already used to use.
-
-#### Authentication
-
-* [Devise](docs/integrations/devise.md)
-
-#### Rich Text Editor
-
-* [CKEditor](docs/integrations/ckeditor.mb.md)
-
-#### File upload
-
-* [Paperclip](docs/integrations/paperclip.md)
-

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ When you use Carnival you'll benefit from a set of features out-of-the-box. If y
   - Remote Actions
   - Custom Actions
   - Batch Operations
-  - Custom Css Cel
+  - Custom CSS Cell
   - Delete
   - CSV Export
 
@@ -37,8 +37,6 @@ When you use Carnival you'll benefit from a set of features out-of-the-box. If y
   - Update existent
   - Nested Form
   - Associate an existent
-  - Create new
-  - Update
   - Delete
   - ImagePreview
   - Relation select (Autocomplete)

--- a/docs/action.md
+++ b/docs/action.md
@@ -1,8 +1,8 @@
 # action
 
-  Define the actions of the presenter. The Carnival Gem has 4 default actions => [:show, :edit, :destroy, :new]
+  Define the actions of the presenter. The Carnival gem has 4 default actions => [:show, :edit, :destroy, :new]
 
-## Parametes:
+## Parameters
 
   - target
     - [:page, :record]
@@ -15,9 +15,11 @@
   - remote
     - boolean
 
-  The parameters below are only valid for actions remotes:
+### Parameters for remote actions
 
-  - method:
+The following are valid only for remote actions:
+
+  - method
     - Method used in the Request
     - default\_value: 'GET'
 
@@ -31,11 +33,12 @@
 
 
 #### :hide_if
-  - Your actions can have custom visibility, for example if you want show it only for an admin_user, for that you must specify a hide if, options when defining the action. This must be a proc or a lambda, if it returns true the action will not be shown.
 
-  - The hide_if Proc/lambda is executed in the controller action, so you have access to all of the controller variables and the @record variable is injected in the action, so you can make conditions using the record data.
+  - Your actions can have custom visibility, if you want for instance to show them only to an admin_user. To do that you must specify a `hide_if` option when defining the action. This must be a proc or a lambda and if it returns `true` the scope will not be shown.
 
-  -Following is an example of how to define a custom action visibility:
+  - The `hide_if` proc/lambda is executed in the controller action, so you have access to all of the controller variables and the @record variable is injected in the action, so you can make conditions using the record data.
+
+Example:
   ``` ruby
     action  :remove_from_blacklist,
             :remote => true,

--- a/docs/integrations/devise.md
+++ b/docs/integrations/devise.md
@@ -14,11 +14,9 @@ end
   
 ## Customize Header to add CurrentUser info and SignOut link
 
-Create a partial "carnival/_extra_header.html.haml(erb)" in you views folder
+Create a partial "carnival/_extra_header.html.haml(erb)" in your views folder
 
-Ex.
-
-![Extra Header Partial](https://dl.dropboxusercontent.com/u/2134454/cdn/carnival/carnival-extra-header-sample-file.png)
+E.g. ![Extra Header Partial](https://dl.dropboxusercontent.com/u/2134454/cdn/carnival/carnival-extra-header-sample-file.png)
 
 Sample content:
 ```ruby
@@ -32,6 +30,5 @@ Sample content:
       = image_tag "", :class => "default"
 ``` 
 
-Rendered Header:
-![Extra Header Rendered](https://dl.dropboxusercontent.com/u/2134454/cdn/carnival/carnival-extra-header-rendered.png)
+Rendered Header: ![Extra Header Rendered](https://dl.dropboxusercontent.com/u/2134454/cdn/carnival/carnival-extra-header-rendered.png)
 

--- a/docs/integrations/paperclip.md
+++ b/docs/integrations/paperclip.md
@@ -3,7 +3,7 @@
 Install and configure following the [Paperclip installation instructions](https://github.com/thoughtbot/paperclip#installation)
 
 ## Configure migration to use Paperclip
-Configure the migration to use Paperclip for a specific field, in the example bellow Paperclip will be used to upload a file to `image` attribute.
+Configure the migration to use Paperclip for a specific field, in the example below Paperclip will be used to upload a file to `image` attribute.
 
 
 ```ruby
@@ -18,7 +18,7 @@ Configure the migration to use Paperclip for a specific field, in the example be
 
 
 ## Configure model to use Paperclip
-Configure the model to use Paperclip for a specific field, in the example bellow Paperclip will be used to upload a file to `image` attribute.
+Configure the model to use Paperclip for a specific field, in the example below Paperclip will be used to upload a file to `image` attribute.
 
 
 ```ruby
@@ -33,8 +33,8 @@ end
 
 ```
 
-## Configure Presenter to use admin_previewable_input
-In your presenter use the admin_previewable_file input to handle the field configures with paperclip.
+## Configure Presenter to use admin_previewable_file
+In your presenter use the admin_previewable_file input to handle the field configured with Paperclip.
 
 ```ruby
 
@@ -45,11 +45,11 @@ In your presenter use the admin_previewable_file input to handle the field confi
 
 Example of the rendered edit form:
 
-![Upload With paperclip](https://dl.dropboxusercontent.com/u/2134454/cdn/carnival/carnival-paperclip-upload.png)
+![Upload With Paperclip](https://dl.dropboxusercontent.com/u/2134454/cdn/carnival/carnival-paperclip-upload.png)
 
-## Full functional Sample Application
+## Fully functional Sample Application
 
-### Sourcecode
+### Source Code
 * [Carnivel Sample Application on Github](https://github.com/Vizir/carnival-sample-application)
 * Sample Presenter source code using the Paperclip Integration - [Photo Presenter](https://github.com/Vizir/carnival-sample-application/blob/master/app/presenters/photo_presenter.rb)
 

--- a/docs/scope.md
+++ b/docs/scope.md
@@ -51,12 +51,11 @@ end
 
 ### Custom visibility
 
-Your scopes can have custom visibility, for example if you want show it only for an admin_user,
-for that you must specify a hide_if, options when defining the scope. This must be a proc or a
-lambda, if it returns true the scope will not be shown.
-This is executed in the controller binding, so you have access to everything the current controller has
-Following is an example of how to define a custom scope visibility:
+Your scopes can have custom visibility, if you want for instance to show them only to an admin_user. To do that you must specify a `hide_if` option when defining the scope. This must be a proc or a lambda and if it returns `true` the scope will not be shown.
+This is executed in the controller binding, so you have access to everything the current controller has.
+
+Example:
 ``` ruby
-scope :all, hide_if: proc { !current_user.admin?  }
-scope :subset, hide_if: -> { !current_user.has_role('role')?  }
+scope :all, hide_if: proc { !current_user.admin? }
+scope :subset, hide_if: -> { !current_user.has_role?('role') }
 ```


### PR DESCRIPTION
Fixed some english typos (e.g. "bellow" for "below" and so on) and
rephrased some parts to enforce clarity and keep the documentation more idiomatic (e.g. using "regular" instead of "common").